### PR TITLE
fix save order of thread and post in djeddit.views.create_thread

### DIFF
--- a/djeddit/views.py
+++ b/djeddit/views.py
@@ -34,13 +34,13 @@ def createThread(request, topic_title=None):
                 if threadForm.is_valid() and postForm.is_valid():
                     thread = threadForm.save(commit=False)
                     post = postForm.save(commit=False)
-                    thread.op = post
-                    thread.topic = topic
                     post.setMeta(request)
-                    thread.save()
                     if is_authenticated(request):
                         post.created_by = request.user
                     post.save()
+                    thread.op = post
+                    thread.topic = topic
+                    thread.save()
                     return HttpResponseRedirect(thread.relativeUrl)
             else:
                 threadForm = ThreadForm(prefix='thread')


### PR DESCRIPTION
using the current save order, saving thread will create a foreign key lookup error, since the OP doesn't exist in the posts table yet.